### PR TITLE
feat: search recursively

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -172,7 +172,7 @@ let
             { ${removeSuffix ".nix" entry} = "${dir}/${entry}"; }
           else if pathExists dirDefault && readFileType dirDefault == "regular" then
             { ${entry} = dirDefault; }
-          else { }
+          else (readModules entry)
         )
         (readDir dir)
     else { }


### PR DESCRIPTION
Modification to `readModules` that searches recursively and stops at a directory with a `default.nix` file.